### PR TITLE
Fix for issue 24

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ loader_version=0.15.7
 fabric_version=0.96.3+1.20.4
 
 # Mod Properties
-	mod_version = 1.4.7
+	mod_version = 1.4.8
 	maven_group = net.cyanmarine
 	archives_base_name = SimpleVeinminer
 

--- a/src/main/java/net/cyanmarine/simpleveinminer/SimpleVeinminer.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/SimpleVeinminer.java
@@ -68,7 +68,7 @@ public class SimpleVeinminer implements ModInitializer {
         return new Identifier(MOD_ID, name);
     }
 
-    private static BlockState[] STATES = {
+    private static final BlockState[] STATES = {
             Blocks.RED_STAINED_GLASS.getDefaultState(),
             Blocks.ORANGE_STAINED_GLASS.getDefaultState(),
             Blocks.YELLOW_STAINED_GLASS.getDefaultState(),
@@ -152,16 +152,14 @@ public class SimpleVeinminer implements ModInitializer {
                 // LOGGER.info("Crawling through depth " + d);
                 ArrayList<ArrayList<BlockPos>> _crawlers = crawlers.get(d);
                 ArrayList<ArrayList<BlockPos>> next = new ArrayList<>();
-                for (int j = 0; j < _crawlers.size(); j++) {
-                    ArrayList<BlockPos> crawler = _crawlers.get(j);
-                    for (int i = 0; i < crawler.size(); i++) {
+                for (ArrayList<BlockPos> crawler : _crawlers) {
+                    for (BlockPos pos : crawler) {
                         t++;
-                        BlockPos pos = crawler.get(i);
                         ArrayList<BlockPos> newCrawler = (testAroundBlock(blocksTested, blocksToBreak, maxBlocks, world, compareTo, radius, pos, 1 + d, debug, tagList, chainReactions, player, restrictions));
 
-                        if (d < radius - 2 && newCrawler.size() > 0) {
+                        if (d < radius - 2 && !newCrawler.isEmpty()) {
                             ///LOGGER.info("New crawler size (pre filter): " + newCrawler.size());
-                            ArrayList<BlockPos> filteredCrawler = new ArrayList<BlockPos>();
+                            ArrayList<BlockPos> filteredCrawler = new ArrayList<>();
                             for (BlockPos newCrawlerPos : newCrawler) {
                                 if (blocksToCrawl.contains(newCrawlerPos)) continue;
                                 filteredCrawler.add(newCrawlerPos);

--- a/src/main/java/net/cyanmarine/simpleveinminer/client/SimpleVeinminerClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/client/SimpleVeinminerClient.java
@@ -205,9 +205,7 @@ public class SimpleVeinminerClient implements ClientModInitializer {
         ClientPlayNetworking.registerGlobalReceiver(Constants.SERVERSIDE_UPDATE, (client, handler, buf, responseSender) -> {
             boolean newValue = buf.readBoolean();
 
-            client.execute(() -> {
-                isVeinMiningServerSide = newValue;
-            });
+            client.execute(() -> isVeinMiningServerSide = newValue);
         });
 
         LOGGER.info("Simple VeinMiner initialized");

--- a/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegister.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegister.java
@@ -62,7 +62,11 @@ public class CommandRegister {
                                             context.getSource().sendMessage(Text.of("Veinmining \"spread\" set to " + spread));
                                             return 1;
                                         }))
-                                )
+                                ).executes(context -> {
+                                    int spread = SimpleVeinminer.getConfig().limits.radius;
+                                    context.getSource().sendMessage(Text.of("Veinmining \"spread\" is " + spread));
+                                    return 1;
+                                })
                             ).then(
                                     literal("materialBasedLimits").then(
                                             argument("value", BoolArgumentType.bool()).executes((context) -> {
@@ -178,13 +182,13 @@ public class CommandRegister {
                                     ).then(
                                             literal("clear").executes((context) -> {
                                                 SimpleVeinminer.getConfig().restrictions.restrictionList.setList(new ArrayList<>());
-                                                context.getSource().sendMessage(Text.of("Cleared list"));
+                                                context.getSource().sendMessage(Text.of("List cleared"));
                                                 return 1;
                                             })
                                     ).executes(context -> {
                                         List<String> list = SimpleVeinminer.getConfig().restrictions.restrictionList.list;
 
-                                        if (list.size() == 0) {
+                                        if (list.isEmpty()) {
                                             context.getSource().sendMessage(Text.of("List is empty"));
                                             context.getSource().sendMessage(Text.of("To add blocks, use \"/veinminer restrictions list add <id/tag>\""));
                                             context.getSource().sendMessage(Text.of("To remove blocks, use \"/veinminer restrictions list remove <id/tag>\""));
@@ -217,7 +221,7 @@ public class CommandRegister {
                                                         String newValue = StringArgumentType.getString(context, "value");
 //                                                        SimpleVeinminer.LOGGER.info("Adding " + newValue + " to list");
                                                         SimpleVeinminer.getConfig().restrictions.restrictionTags.add(newValue);
-                                                        context.getSource().sendMessage(Text.of("Added " + newValue + " to list"));
+                                                        context.getSource().sendMessage(Text.of("Added " + newValue + " to tags list"));
                                                         return 1;
                                                     })
                                             )
@@ -240,12 +244,12 @@ public class CommandRegister {
                                             })
                                     ).executes((context)->{
                                         List<String> list = SimpleVeinminer.getConfig().restrictions.restrictionTags.tags;
-                                        if (list.size() == 0) {
-                                            context.getSource().sendMessage(Text.of("List is empty"));
+                                        if (list.isEmpty()) {
+                                            context.getSource().sendMessage(Text.of("Tag list is empty"));
                                             context.getSource().sendMessage(Text.of("To add tags, use \"/veinminer restrictions tags add <tag>\""));
                                             return 1;
                                         } else {
-                                            context.getSource().sendMessage(Text.of("List:"));
+                                            context.getSource().sendMessage(Text.of("Tag list:"));
                                             list.forEach(s -> context.getSource().sendMessage(Text.of(s)));
                                         }
                                         return 1;

--- a/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegisterClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegisterClient.java
@@ -2,30 +2,19 @@ package net.cyanmarine.simpleveinminer.commands;
 
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
-import com.mojang.brigadier.context.CommandContext;
 import me.shedaniel.math.Color;
 import net.cyanmarine.simpleveinminer.client.SimpleVeinminerClient;
+import net.cyanmarine.simpleveinminer.commands.argumenttypes.AnchorArgumentType;
 import net.cyanmarine.simpleveinminer.commands.argumenttypes.HighlightModesArgumentType;
 import net.cyanmarine.simpleveinminer.config.SimpleConfigClient;
+import net.cyanmarine.simpleveinminer.config.enums.*;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.text.Text;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
 
 public class CommandRegisterClient {
-    private int setVerticalAnchor(CommandContext<FabricClientCommandSource> context, SimpleConfigClient.HudDisplay.VERTICAL_ANCHOR anchor) {
-        SimpleVeinminerClient.getConfig().setHudVerticalAnchor(anchor);
-        context.getSource().getPlayer().sendMessage(Text.of("Hud vertical anchor set to top"));
-        return 1;
-    }
-    private int setHorizontalAnchor(CommandContext<FabricClientCommandSource> context, SimpleConfigClient.HudDisplay.HORIZONTAL_ANCHOR anchor) {
-        SimpleVeinminerClient.getConfig().setHudHorizontalAnchor(anchor);
-        context.getSource().getPlayer().sendMessage(Text.of("Hud horizontal anchor set to top"));
-        return 1;
-    }
-
     public CommandRegisterClient() {
         SimpleVeinminerClient.LOGGER.info("Initializing client commands");
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
@@ -37,7 +26,7 @@ public class CommandRegisterClient {
                                                             .executes((context) -> {
                                                                 int x = IntegerArgumentType.getInteger(context, "value");
                                                                 SimpleVeinminerClient.getConfig().setHudX(x);
-                                                                context.getSource().getPlayer().sendMessage(Text.of("Hud x position set to " + x));
+                                                                context.getSource().getPlayer().sendMessage(Text.of("Hud X position set to " + x));
                                                                 return 1;
                                                             })
                                             )
@@ -47,7 +36,7 @@ public class CommandRegisterClient {
                                                             .executes((context) -> {
                                                                 int y = IntegerArgumentType.getInteger(context, "value");
                                                                 SimpleVeinminerClient.getConfig().setHudY(y);
-                                                                context.getSource().getPlayer().sendMessage(Text.of("Hud y position set to " + y));
+                                                                context.getSource().getPlayer().sendMessage(Text.of("Hud Y position set to " + y));
                                                                 return 1;
                                                             })
                                             )
@@ -60,21 +49,40 @@ public class CommandRegisterClient {
                             ).then(
                                     literal("anchor").then(
                                             literal("vertical").then(
-                                                    literal("top").executes((context) -> setVerticalAnchor(context, SimpleConfigClient.HudDisplay.VERTICAL_ANCHOR.TOP))
-                                            ).then(
-                                                    literal("center").executes((context) -> setVerticalAnchor(context, SimpleConfigClient.HudDisplay.VERTICAL_ANCHOR.CENTER))
-                                            ).then(
-                                                    literal("bottom").executes((context) -> setVerticalAnchor(context, SimpleConfigClient.HudDisplay.VERTICAL_ANCHOR.BOTTOM))
-                                            )
+                                                      argument("value", AnchorArgumentType.verticalAnchor())
+                                                              .executes(context -> {
+                                                                  VerticalAnchor anchor = AnchorArgumentType.getVerticalAnchor(context, "value");
+                                                                  SimpleVeinminerClient.getConfig().setHudVerticalAnchor(anchor);
+                                                                  context.getSource().getPlayer().sendMessage(Text.of("Hud vertical anchor set to " + anchor.asString()));
+                                                                  return 1;
+                                                              })
+                                            ).executes(context -> {
+                                                VerticalAnchor anchor = SimpleVeinminerClient.getConfig().hudDisplay.vertical_anchor;
+                                                context.getSource().getPlayer().sendMessage(Text.of("Hud vertical anchor is set to " + anchor.asString()));
+                                                return  1;
+                                            })
                                     ).then(
                                             literal("horizontal").then(
-                                                    literal("left").executes((context) -> setHorizontalAnchor(context, SimpleConfigClient.HudDisplay.HORIZONTAL_ANCHOR.LEFT))
-                                            ).then(
-                                                    literal("center").executes((context) -> setHorizontalAnchor(context, SimpleConfigClient.HudDisplay.HORIZONTAL_ANCHOR.CENTER))
-                                            ).then(
-                                                    literal("right").executes((context) -> setHorizontalAnchor(context, SimpleConfigClient.HudDisplay.HORIZONTAL_ANCHOR.RIGHT))
-                                            )
-                                    )
+                                                    argument("value", AnchorArgumentType.horizontalAnchor())
+                                                            .executes(context -> {
+                                                                HorizontalAnchor anchor = AnchorArgumentType.getHorizontalAnchor(context, "value");
+                                                                SimpleVeinminerClient.getConfig().setHudHorizontalAnchor(anchor);
+                                                                context.getSource().getPlayer().sendMessage(Text.of("Hud horizontal anchor set to " + anchor.asString()));
+                                                                return 1;
+                                                            })
+                                            ).executes(context -> {
+                                                HorizontalAnchor anchor = SimpleVeinminerClient.getConfig().hudDisplay.horizontal_anchor;
+                                                context.getSource().getPlayer().sendMessage(Text.of("Hud horizontal anchor is set to " + anchor.asString()));
+                                                return  1;
+                                            })
+                                    ).executes(context -> {
+                                        VerticalAnchor vAnchor = SimpleVeinminerClient.getConfig().hudDisplay.vertical_anchor;
+                                        HorizontalAnchor hAnchor = SimpleVeinminerClient.getConfig().hudDisplay.horizontal_anchor;
+                                        context.getSource().getPlayer().sendMessage(Text.of("Hud anchors' values are:"));
+                                        context.getSource().getPlayer().sendMessage(Text.of("    Vertical is set to " + vAnchor.asString()));
+                                        context.getSource().getPlayer().sendMessage(Text.of("    Horizontal is set to " + hAnchor.asString()));
+                                        return 1;
+                                    })
                             ).then(
                                     literal("show").then(
                                             literal("block").then(
@@ -138,7 +146,7 @@ public class CommandRegisterClient {
                                     ).then(
                                             literal("opacity")
                                                     .then(
-                                                            argument("value", IntegerArgumentType.integer(1, 10000))
+                                                            argument("value", IntegerArgumentType.integer(1, 100))
                                                                     .executes((context) -> {
                                                                         int opacity = IntegerArgumentType.getInteger(context, "value");
                                                                         SimpleVeinminerClient.getConfig().setOpacity(opacity);

--- a/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegisterClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegisterClient.java
@@ -29,7 +29,11 @@ public class CommandRegisterClient {
                                                                 context.getSource().getPlayer().sendMessage(Text.of("Hud X position set to " + x));
                                                                 return 1;
                                                             })
-                                            )
+                                            ).executes(context -> {
+                                                int x = SimpleVeinminerClient.getConfig().hudDisplay.x;
+                                                context.getSource().getPlayer().sendMessage(Text.of("Hud position X is " + x));
+                                                return 1;
+                                            })
                                     ).then(
                                             literal("y").then(
                                                     argument("value", IntegerArgumentType.integer())
@@ -39,7 +43,11 @@ public class CommandRegisterClient {
                                                                 context.getSource().getPlayer().sendMessage(Text.of("Hud Y position set to " + y));
                                                                 return 1;
                                                             })
-                                            )
+                                            ).executes(context -> {
+                                                int y = SimpleVeinminerClient.getConfig().hudDisplay.y;
+                                                context.getSource().getPlayer().sendMessage(Text.of("Hud position Y is " + y));
+                                                return 1;
+                                            })
                                     ).executes((context) -> {
                                         int x = SimpleVeinminerClient.getConfig().hudDisplay.x;
                                         int y = SimpleVeinminerClient.getConfig().hudDisplay.y;

--- a/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegisterClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/commands/CommandRegisterClient.java
@@ -121,7 +121,7 @@ public class CommandRegisterClient {
                                     )
                             ).then(
                                     literal("spacing").then(
-                                            argument("value", IntegerArgumentType.integer())
+                                            argument("value", IntegerArgumentType.integer(0))
                                                     .executes((context) -> {
                                                         int spacing = IntegerArgumentType.getInteger(context, "value");
                                                         SimpleVeinminerClient.getConfig().setHudBlockNumberSpacing(spacing);
@@ -154,7 +154,7 @@ public class CommandRegisterClient {
                                     ).then(
                                             literal("opacity")
                                                     .then(
-                                                            argument("value", IntegerArgumentType.integer(1, 100))
+                                                            argument("value", IntegerArgumentType.integer(0, 100))
                                                                     .executes((context) -> {
                                                                         int opacity = IntegerArgumentType.getInteger(context, "value");
                                                                         SimpleVeinminerClient.getConfig().setOpacity(opacity);

--- a/src/main/java/net/cyanmarine/simpleveinminer/commands/argumenttypes/AnchorArgumentType.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/commands/argumenttypes/AnchorArgumentType.java
@@ -1,0 +1,29 @@
+package net.cyanmarine.simpleveinminer.commands.argumenttypes;
+
+import com.mojang.brigadier.context.CommandContext;
+import net.cyanmarine.simpleveinminer.config.enums.*;
+import net.minecraft.command.argument.EnumArgumentType;
+
+public class AnchorArgumentType {
+    public static VerticalAnchorArgumentType verticalAnchor() { return new VerticalAnchorArgumentType(); }
+    public static <S> VerticalAnchor getVerticalAnchor(CommandContext<S> context, String id){
+        return context.getArgument(id, VerticalAnchor.class);
+    }
+    public static HorizontalAnchorArgumentType horizontalAnchor() { return new HorizontalAnchorArgumentType(); }
+    public static <S> HorizontalAnchor getHorizontalAnchor(CommandContext<S> context, String id){
+        return context.getArgument(id, HorizontalAnchor.class);
+    }
+
+    public static class VerticalAnchorArgumentType extends EnumArgumentType<VerticalAnchor>
+    {
+        private VerticalAnchorArgumentType() {
+            super(VerticalAnchor.CODEC, VerticalAnchor::values);
+        }
+    }
+    public static class HorizontalAnchorArgumentType extends EnumArgumentType<HorizontalAnchor>
+    {
+        private HorizontalAnchorArgumentType() {
+            super(HorizontalAnchor.CODEC, HorizontalAnchor::values);
+        }
+    }
+}

--- a/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfig.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfig.java
@@ -75,6 +75,7 @@ public class SimpleConfig extends Config implements ConfigContainer {
 
     @ConfigEntries(includeAll = true)
     public static class Limits implements ConfigGroup {
+        @ConfigEntry.BoundedInteger(min = 1)
         public int maxBlocks = 150;
         public boolean materialBasedLimits = false;
         @ConfigEntry.BoundedInteger(min = 1)
@@ -86,7 +87,7 @@ public class SimpleConfig extends Config implements ConfigContainer {
         }
 
         public void setMaxBlocks(int maxBlocks) {
-            this.maxBlocks = maxBlocks;
+            this.maxBlocks = Math.max(1, maxBlocks);
             syncConfig();
         }
 
@@ -96,8 +97,7 @@ public class SimpleConfig extends Config implements ConfigContainer {
         }
 
         public void setRadius(int radius) {
-            if (radius < 1) radius = 1;
-            this.radius = radius;
+            this.radius = Math.max(1, radius);
             syncConfig();
         }
 
@@ -228,8 +228,10 @@ public class SimpleConfig extends Config implements ConfigContainer {
     @ConfigEntries(includeAll = true)
     public static class Exhaustion implements ConfigGroup {
         public boolean exhaust = true;
+        @ConfigEntry.BoundedDouble(min = 0)
         public double baseValue = 0.3;
         public boolean exhaustionBasedOnHardness = true;
+        @ConfigEntry.BoundedDouble(min = 0)
         public double hardnessWeight = 0.1;
 
         public void setExhaust(boolean exhaust) {
@@ -238,7 +240,7 @@ public class SimpleConfig extends Config implements ConfigContainer {
         }
 
         public void setBaseValue(double baseValue) {
-            this.baseValue = baseValue;
+            this.baseValue = Math.max(0, baseValue);
             SimpleVeinminer.getConfig().save();
         }
 
@@ -248,24 +250,26 @@ public class SimpleConfig extends Config implements ConfigContainer {
         }
 
         public void setHardnessWeight(double hardnessWeight) {
-            this.hardnessWeight = hardnessWeight;
+            this.hardnessWeight = Math.max(0, hardnessWeight);
             SimpleVeinminer.getConfig().save();
         }
     }
 
     @ConfigEntries(includeAll = true)
     public static class Durability implements ConfigGroup {
+        @ConfigEntry.BoundedDouble(min = 0)
         public double damageMultiplier = 1.0;
+        @ConfigEntry.BoundedDouble(min = 0)
         public double swordMultiplier = 2.0;
         public boolean consumeOnInstantBreak = false;
 
         public void setDamageMultiplier(double damageMultiplier) {
-            this.damageMultiplier = damageMultiplier;
+            this.damageMultiplier = Math.max(0, damageMultiplier);
             SimpleVeinminer.getConfig().save();
         }
 
         public void setSwordMultiplier(double swordMultiplier) {
-            this.swordMultiplier = swordMultiplier;
+            this.swordMultiplier = Math.max(0, swordMultiplier);
             SimpleVeinminer.getConfig().save();
         }
 

--- a/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfigClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfigClient.java
@@ -141,6 +141,7 @@ public class SimpleConfigClient extends SimpleConfig {
         public MODES mode = MODES.OUTLINE;
         public boolean highlightAllSides = false;
         // public boolean onlyExposed = false;
+        @ConfigEntry.BoundedInteger(min = 0)
         public int updateRate = 20;
 
 
@@ -160,6 +161,7 @@ public class SimpleConfigClient extends SimpleConfig {
         public int x = 16;
         public int y = 0;
         public boolean showBlock = true;
+        @ConfigEntry.BoundedInteger(min = 0)
         public int blockNumberSpacing = 16;
     }
 }

--- a/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfigClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfigClient.java
@@ -4,6 +4,7 @@ import me.lortseam.completeconfig.api.ConfigEntries;
 import me.lortseam.completeconfig.api.ConfigEntry;
 import me.lortseam.completeconfig.api.ConfigGroup;
 import me.shedaniel.math.Color;
+import net.cyanmarine.simpleveinminer.config.enums.*;
 import net.minecraft.util.math.MathHelper;
 
 @ConfigEntries(includeAll = true)
@@ -98,11 +99,11 @@ public class SimpleConfigClient extends SimpleConfig {
         this.hudDisplay.y = y;
         this._save();
     }
-    public void setHudVerticalAnchor(HudDisplay.VERTICAL_ANCHOR vertical_anchor) {
+    public void setHudVerticalAnchor(VerticalAnchor vertical_anchor) {
         this.hudDisplay.vertical_anchor = vertical_anchor;
         this._save();
     }
-    public void setHudHorizontalAnchor(HudDisplay.HORIZONTAL_ANCHOR horizontal_anchor) {
+    public void setHudHorizontalAnchor(HorizontalAnchor horizontal_anchor) {
         this.hudDisplay.horizontal_anchor = horizontal_anchor;
         this._save();
     }
@@ -132,7 +133,7 @@ public class SimpleConfigClient extends SimpleConfig {
     public static class Highlight implements ConfigGroup {
         public boolean doHighlight = true;
         @ConfigEntry.Color(alphaMode = false)
-        public Color color = Color.ofOpaque(0xFFFFFF);
+        public Color color = Color.ofTransparent(0xFFFFFF);
         @ConfigEntry.Slider(valueKey = "opacity.value")
         @ConfigEntry.IntegerSliderInterval(1)
         @ConfigEntry.BoundedInteger(min = 0, max = 100)
@@ -154,22 +155,11 @@ public class SimpleConfigClient extends SimpleConfig {
     @ConfigEntries(includeAll = true)
     public static class HudDisplay implements ConfigGroup {
         public boolean showCount = true;
-        public VERTICAL_ANCHOR vertical_anchor = VERTICAL_ANCHOR.CENTER;
-        public HORIZONTAL_ANCHOR horizontal_anchor = HORIZONTAL_ANCHOR.CENTER;
+        public VerticalAnchor vertical_anchor = VerticalAnchor.CENTER;
+        public HorizontalAnchor horizontal_anchor = HorizontalAnchor.CENTER;
         public int x = 16;
         public int y = 0;
         public boolean showBlock = true;
         public int blockNumberSpacing = 16;
-
-        public enum VERTICAL_ANCHOR {
-            TOP,
-            CENTER,
-            BOTTOM
-        }
-        public enum HORIZONTAL_ANCHOR {
-            LEFT,
-            CENTER,
-            RIGHT
-        }
     }
 }

--- a/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfigClient.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/config/SimpleConfigClient.java
@@ -4,9 +4,11 @@ import me.lortseam.completeconfig.api.ConfigEntries;
 import me.lortseam.completeconfig.api.ConfigEntry;
 import me.lortseam.completeconfig.api.ConfigGroup;
 import me.shedaniel.math.Color;
+import net.minecraft.util.math.MathHelper;
 
 @ConfigEntries(includeAll = true)
 public class SimpleConfigClient extends SimpleConfig {
+    @ConfigEntry.BoundedInteger(min = 0)
     public int clientRadius = 1;
     public boolean showMiningProgress = true;
     public boolean showRestrictionMessages = true;
@@ -32,7 +34,7 @@ public class SimpleConfigClient extends SimpleConfig {
     }
 
     public void setClientRadius(int clientRadius) {
-        this.clientRadius = Math.min(5, Math.max(1, clientRadius));
+        this.clientRadius = MathHelper.clamp(clientRadius, 1, 5);
         this._save();
     }
 

--- a/src/main/java/net/cyanmarine/simpleveinminer/config/enums/HorizontalAnchor.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/config/enums/HorizontalAnchor.java
@@ -1,0 +1,26 @@
+package net.cyanmarine.simpleveinminer.config.enums;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.util.StringIdentifiable;
+
+public enum HorizontalAnchor implements StringIdentifiable {
+
+    LEFT("left"),
+    CENTER("center"),
+    RIGHT("right");
+
+    public static final Codec<HorizontalAnchor> CODEC;
+    private final String id;
+
+    HorizontalAnchor(String id) {
+        this.id = id;
+    }
+    @Override
+    public String asString() {
+        return this.id;
+    }
+
+    static {
+        CODEC = StringIdentifiable.createCodec(HorizontalAnchor::values);
+    }
+}

--- a/src/main/java/net/cyanmarine/simpleveinminer/config/enums/VerticalAnchor.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/config/enums/VerticalAnchor.java
@@ -1,0 +1,25 @@
+package net.cyanmarine.simpleveinminer.config.enums;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.util.StringIdentifiable;
+
+public enum VerticalAnchor implements StringIdentifiable {
+    TOP("top"),
+    CENTER("center"),
+    BOTTOM("bottom");
+
+    public static final Codec<VerticalAnchor> CODEC;
+    private final String id;
+
+    VerticalAnchor(String id) {
+        this.id = id;
+    }
+    @Override
+    public String asString() {
+        return this.id;
+    }
+
+    static {
+        CODEC = StringIdentifiable.createCodec(VerticalAnchor::values);
+    }
+}

--- a/src/main/java/net/cyanmarine/simpleveinminer/mixin/BlockMixin.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/mixin/BlockMixin.java
@@ -55,26 +55,43 @@ public abstract class BlockMixin {
         // SimpleVeinminer.LOGGER.info(exhaustion.baseValue + " " + exhaustion.hardnessWeight);
         SimpleConfig.Durability durability = config.durability;
         double damageMultiplier = durability.damageMultiplier;
-        if (handItem instanceof SwordItem || handItem instanceof TridentItem) damageMultiplier *= durability.swordMultiplier;
+        if (isSpecialItem(handItem)) damageMultiplier *= durability.swordMultiplier;
         boolean debug = SimpleVeinminer.isDebug();
+
+
+        /* Damage limit while veinmining
+        Keep in mind that the damage of the first block is calculated *after* breaking every other block.
+        The damage dealt by Block 0 is the default vanilla value (1 for items & 2 for sword/tridents).
+
+        Meaning of maxAllowedDamage's value: We should veinmine while the durability is greater than damageMultiplier
+        (and so the durability for breaking Block 0 is at least 1 when we finish veinmining)
+        */
+        int maxAllowedDamage = hand.getMaxDamage() - (int) damageMultiplier;
 
         ArrayList<BlockPos> blocksToBreak = SimpleVeinminer.getBlocksToVeinmine(pos, state, SimpleVeinminer.getMaxBlocks(handItem), SimpleVeinminer.getVeinminingRadius(player), SimpleVeinminer.getSpreadAccuracy(), player, debug, config.restrictions.onlyBreakBottomBlockForChainReactions);
         if (debug) world.setBlockState(pos, Blocks.BEDROCK.getDefaultState());
-        for (int i = 0; i < blocksToBreak.size(); i++) {
-            BlockPos currentPos = blocksToBreak.get(i);
+
+        // Skip Block 0 as the player breaks this block directly
+        for (BlockPos currentPos : blocksToBreak.subList(1, blocksToBreak.size())) {
+            BlockState currentState = world.getBlockState(currentPos);
+            Block currentBlock = currentState.getBlock();
+
+            // Check if we can veinmine blocks
+            boolean doDamage = shouldDamage(player, hand, currentBlock, durability);
+            SimpleVeinminer.LOGGER.info(hand.getDamage() + "/" + hand.getMaxDamage());
+            if (doDamage && (hand.getDamage() >= maxAllowedDamage || (config.restrictions.keepToolFromBreaking && hand.getDamage() >= maxAllowedDamage - 1)))
+                break;
+
+            // Do veinmining
+            if (currentState.isAir()) continue;
             if (debug) {
                 world.setBlockState(currentPos, Blocks.BEDROCK.getDefaultState());
                 continue;
             }
-
-            BlockState currentState = world.getBlockState(currentPos);
-            if (currentState.isAir()) continue;
-            Block currentBlock = currentState.getBlock();
             BlockEntity currentBlockEntity = world.getBlockEntity(currentPos);
             //world.breakBlock(currentPos, false);
 
             boolean willDrop = shouldDrop(player, hand, currentState);
-
             List<ItemStack> stacks = getDroppedStacks(currentState, (ServerWorld) world, currentPos, currentBlockEntity, player, hand);
             if (willDrop && stacks != null)
                 stacks.forEach((stack) -> {
@@ -89,7 +106,6 @@ public abstract class BlockMixin {
 
             player.incrementStat(Stats.MINED.getOrCreateStat(currentBlock));
 
-            boolean doDamage = i > 0 && shouldDamage(player, hand, currentBlock, durability);
 
             if (doDamage)
                 hand.damage((int) (damageMultiplier), player.getRandom(), (ServerPlayerEntity) player);
@@ -98,8 +114,6 @@ public abstract class BlockMixin {
                 double totalExhausted = (exhaustion.baseValue + (exhaustion.exhaustionBasedOnHardness ? (currentBlock.getHardness() * exhaustion.hardnessWeight) : 0));
                 player.addExhaustion((float) totalExhausted);
             }
-//            SimpleVeinminer.LOGGER.info(hand.getDamage() + "/" + hand.getMaxDamage());
-            if (doDamage && (hand.getDamage() >= hand.getMaxDamage() || (config.restrictions.keepToolFromBreaking && hand.getDamage() >= hand.getMaxDamage() - 2))) break;
         }
     }
 
@@ -112,10 +126,16 @@ public abstract class BlockMixin {
     public boolean shouldDamage(PlayerEntity player, ItemStack hand, Block block, SimpleConfig.Durability durability) {
         Item handItem = hand.getItem();
         return !player.isCreative() && hand.isDamageable() && (durability.consumeOnInstantBreak || block.getHardness() > 0) && (
-            handItem instanceof SwordItem ||
-            handItem instanceof TridentItem ||
-            handItem instanceof MiningToolItem ||
-            handItem instanceof ShearsItem
+                isSpecialItem(handItem) ||
+                        handItem instanceof MiningToolItem ||
+                        handItem instanceof ShearsItem
         );
+    }
+
+    /** Compare item to the items that get damaged by 2 when breaking blocks**/
+    @Unique
+    public boolean isSpecialItem(Item item){
+        return item instanceof SwordItem ||
+                item instanceof TridentItem;
     }
 }

--- a/src/main/java/net/cyanmarine/simpleveinminer/mixin/BlockMixin.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/mixin/BlockMixin.java
@@ -55,7 +55,7 @@ public abstract class BlockMixin {
         // SimpleVeinminer.LOGGER.info(exhaustion.baseValue + " " + exhaustion.hardnessWeight);
         SimpleConfig.Durability durability = config.durability;
         double damageMultiplier = durability.damageMultiplier;
-        if (isSpecialItem(handItem)) damageMultiplier *= durability.swordMultiplier;
+        if (isItemSpecial(handItem)) damageMultiplier *= durability.swordMultiplier;
         boolean debug = SimpleVeinminer.isDebug();
 
 
@@ -78,7 +78,7 @@ public abstract class BlockMixin {
 
             // Check if we can veinmine blocks
             boolean doDamage = shouldDamage(player, hand, currentBlock, durability);
-            SimpleVeinminer.LOGGER.info(hand.getDamage() + "/" + hand.getMaxDamage());
+//            SimpleVeinminer.LOGGER.info(hand.getDamage() + "/" + hand.getMaxDamage());
             if (doDamage && (hand.getDamage() >= maxAllowedDamage || (config.restrictions.keepToolFromBreaking && hand.getDamage() >= maxAllowedDamage - 1)))
                 break;
 
@@ -126,7 +126,7 @@ public abstract class BlockMixin {
     public boolean shouldDamage(PlayerEntity player, ItemStack hand, Block block, SimpleConfig.Durability durability) {
         Item handItem = hand.getItem();
         return !player.isCreative() && hand.isDamageable() && (durability.consumeOnInstantBreak || block.getHardness() > 0) && (
-                isSpecialItem(handItem) ||
+                isItemSpecial(handItem) ||
                         handItem instanceof MiningToolItem ||
                         handItem instanceof ShearsItem
         );
@@ -134,7 +134,7 @@ public abstract class BlockMixin {
 
     /** Compare item to the items that get damaged by 2 when breaking blocks**/
     @Unique
-    public boolean isSpecialItem(Item item){
+    public boolean isItemSpecial(Item item){
         return item instanceof SwordItem ||
                 item instanceof TridentItem;
     }

--- a/src/main/java/net/cyanmarine/simpleveinminer/mixin/InGameHudMixin.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/mixin/InGameHudMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -22,6 +23,9 @@ public abstract class InGameHudMixin {
 
     @Shadow @Final private MinecraftClient client;
 
+    // Value to subtract when the vertical anchor is set to BOTTOM
+    // TODO: Draw the block item before the chat box
+    @Unique private final int HOTBAR_HEIGHT = 48;
     @Inject(at = @At("TAIL"), method = "render(Lnet/minecraft/client/gui/DrawContext;F)V")
     public void renderTailInject(DrawContext context, float tickDelta, CallbackInfo ci) {
         if (blocksToHighlight == null) return;
@@ -43,7 +47,7 @@ public abstract class InGameHudMixin {
         }
         switch (hudDisplay.vertical_anchor) {
             case CENTER -> y = client.getWindow().getScaledHeight() / 2 - 8;
-            case BOTTOM -> y = client.getWindow().getScaledHeight()  - 16;
+            case BOTTOM -> y = client.getWindow().getScaledHeight()  - 16 - HOTBAR_HEIGHT;
         }
         if (hudDisplay.horizontal_anchor == HorizontalAnchor.RIGHT) x -= hudDisplay.x;
         else x += hudDisplay.x;

--- a/src/main/java/net/cyanmarine/simpleveinminer/mixin/InGameHudMixin.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/mixin/InGameHudMixin.java
@@ -1,6 +1,7 @@
 package net.cyanmarine.simpleveinminer.mixin;
 
 import net.cyanmarine.simpleveinminer.config.SimpleConfigClient;
+import net.cyanmarine.simpleveinminer.config.enums.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -44,9 +45,9 @@ public abstract class InGameHudMixin {
             case CENTER -> y = client.getWindow().getScaledHeight() / 2 - 8;
             case BOTTOM -> y = client.getWindow().getScaledHeight()  - 16;
         }
-        if (hudDisplay.horizontal_anchor == SimpleConfigClient.HudDisplay.HORIZONTAL_ANCHOR.RIGHT) x -= hudDisplay.x;
+        if (hudDisplay.horizontal_anchor == HorizontalAnchor.RIGHT) x -= hudDisplay.x;
         else x += hudDisplay.x;
-        if (hudDisplay.vertical_anchor == SimpleConfigClient.HudDisplay.VERTICAL_ANCHOR.BOTTOM) y -= hudDisplay.y;
+        if (hudDisplay.vertical_anchor == VerticalAnchor.BOTTOM) y -= hudDisplay.y;
         else y += hudDisplay.y;
 
         if (showBlock) {

--- a/src/main/java/net/cyanmarine/simpleveinminer/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/mixin/WorldRendererMixin.java
@@ -44,12 +44,19 @@ import static net.cyanmarine.simpleveinminer.client.SimpleVeinminerClient.*;
 
 @Mixin(WorldRenderer.class)
 public abstract class WorldRendererMixin {
+    @Unique
     Item holding;
+    @Unique
     BlockPos currentlyOutliningPos;
+    @Unique
     ArrayList<BlockPos> beingBroken;
+    @Unique
     float red, green, blue, alpha;
+    @Unique
     int delay1 = 0;
+    @Unique
     int delay2 = 0;
+    @Unique
     boolean resetCountdown = false;
     @Shadow
     @Nullable
@@ -68,6 +75,7 @@ public abstract class WorldRendererMixin {
     @Shadow
     protected abstract void removeBlockBreakingInfo(BlockBreakingInfo info);
 
+    @Unique
     private void renderPreview(PlayerEntity player, MatrixStack matrices) {
             assert world != null;
             assert blocksToHighlight != null;
@@ -152,7 +160,7 @@ public abstract class WorldRendererMixin {
                 assert client.player != null;
                 Item hand = client.player.getMainHandStack().getItem();
 
-                if (!previewFrozen && (config.isChanged() || (updateRate > 0 && delay1 % updateRate == 0) || !pos.equals(currentlyOutliningPos) || !state.equals(currentlyOutliningState) || !hand.equals(holding))) {
+                if (blocksToHighlight == null || (!previewFrozen && (config.isChanged() || (updateRate > 0 && delay1 % updateRate == 0) || !pos.equals(currentlyOutliningPos) || !state.equals(currentlyOutliningState) || !hand.equals(holding)))) {
                     reset();
                     holding = hand;
                     Color outlineColor = outline.color;
@@ -250,6 +258,7 @@ public abstract class WorldRendererMixin {
         }
     }
 
+    @Unique
     private void clearBlockBreakingProgressions() {
         if (beingBroken != null && blockBreakingProgressions != null)
             for (int i = 0; i < beingBroken.size(); i++) {
@@ -265,6 +274,7 @@ public abstract class WorldRendererMixin {
         beingBroken = null;
     }
 
+    @Unique
     private ArrayList<BlockPos> getBlocksToOutline(BlockPos pos, BlockState state, PlayerEntity player, boolean onlyExposed) {
         ArrayList<BlockPos> willVeinmine = SimpleVeinminer.getBlocksToVeinmine(pos, state, SimpleVeinminer.getMaxBlocks(holding), SimpleVeinminer.getVeinminingRadius(player), SimpleVeinminer.getSpreadAccuracy(), player, SimpleVeinminer.isDebug(), getConfig().restrictions.onlyBreakBottomBlockForChainReactions);
         if (!onlyExposed) return willVeinmine;
@@ -278,6 +288,7 @@ public abstract class WorldRendererMixin {
         return willOutline;
     }
 
+    @Unique
     private boolean hasFaceVisible(BlockPos pos) {
         if (world == null) return false;
         BlockPos[] neighbors = SimpleVeinminer.getNeighbors(pos);
@@ -286,6 +297,7 @@ public abstract class WorldRendererMixin {
         return false;
     }
 
+    @Unique
     private void outline(MatrixStack matrices, VertexConsumer vertexConsumer, Entity entity, double d, double e, double f, BlockPos pos, BlockState state, float r, float g, float b, float a) {
         drawCuboidShapeOutline(matrices, vertexConsumer, state.getOutlineShape(world, pos, ShapeContext.of(entity)), (double) pos.getX() - d, (double) pos.getY() - e, (double) pos.getZ() - f, r, g, b, a);
     }

--- a/src/main/java/net/cyanmarine/simpleveinminer/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/cyanmarine/simpleveinminer/mixin/WorldRendererMixin.java
@@ -131,9 +131,7 @@ public abstract class WorldRendererMixin {
                         drawBox(buffer, positionMatrix, red, green, blue, alpha, new Box(0, 0, 0, 1, 1, 1), highlight, blocksToHighlight, b);
                     case CUBE_SHAPE ->
                         drawBox(buffer, positionMatrix, red, green, blue, alpha, shape.getBoundingBox(), highlight, blocksToHighlight, b);
-                    case OUTLINE -> {
-                        drawOutline(buffer, positionMatrix, red, green, blue, alpha, shape, highlight, blocksToHighlight, b, matrices);
-                    }
+                    case OUTLINE -> drawOutline(buffer, positionMatrix, red, green, blue, alpha, shape, highlight, blocksToHighlight, b, matrices);
                 }
             }
 
@@ -222,8 +220,7 @@ public abstract class WorldRendererMixin {
                 if (beingBroken == null)
                     beingBroken = (ArrayList<BlockPos>) blocksToHighlight.clone();
 
-                for (int i = 0; i < blocksToHighlight.size(); i++) {
-                    BlockPos currentPos = blocksToHighlight.get(i);
+                for (BlockPos currentPos : blocksToHighlight) {
                     if (currentPos.equals(currentlyOutliningPos)) continue;
                     BlockBreakingInfo newBlockBreakingProgress = new BlockBreakingInfo(blockBreakingProgress.hashCode(), currentPos);
                     newBlockBreakingProgress.setStage(stage);
@@ -261,8 +258,7 @@ public abstract class WorldRendererMixin {
     @Unique
     private void clearBlockBreakingProgressions() {
         if (beingBroken != null && blockBreakingProgressions != null)
-            for (int i = 0; i < beingBroken.size(); i++) {
-                BlockPos pos = beingBroken.get(i);
+            for (BlockPos pos : beingBroken) {
                 if (pos.equals(currentlyOutliningPos)) continue;
                 long l = pos.asLong();
                 SortedSet<BlockBreakingInfo> set = this.blockBreakingProgressions.get(l);
@@ -280,8 +276,7 @@ public abstract class WorldRendererMixin {
         if (!onlyExposed) return willVeinmine;
         ArrayList<BlockPos> willOutline = new ArrayList<>();
 
-        for (int i = 0; i < willVeinmine.size(); i++) {
-            BlockPos currentPos = willVeinmine.get(i);
+        for (BlockPos currentPos : willVeinmine) {
             if (hasFaceVisible(currentPos)) willOutline.add(currentPos);
         }
 


### PR DESCRIPTION
The code has a brief description of the changes.

A longer explanation is the following:

## Things to consider
What caused issue #22 was indeed that Block 0 (i.e. `blocksToBreak.get(0)` ) was being broken twice: Once in the for loop (by us) and then again by the player _after_ exiting the `BlockMixin` code. That means that the `blocksToBreak` list would first damage the tool  _before_ the player (when Block 0 breaks). So this led to the next issue (explained in the following section).

As a side note, I tried using `"TAIL"` at the injection but it had no changes on the behaviour.

## Regarding issue #24
### The vanilla case 
Considering that the blocks in `blocksToBreak` will break before the player breaks Block 0, on the simplest case (i.e. damage multipliers are like in vanilla MC), the tool could have 0 durability after exiting the for loop, and then negative durability after breaking Block 0. So, in order to be able to break Block 0 the tool must have at least 1 durability _after exiting the for loop_.  This can be solved by defining a minimum allowed durability value (or a maximum allowed damage, i.e `maxAllowedDamage`) _and_ checking if we can break the first veinmined block (Block 1) _before_ breaking it (thus the `if (cond) break;` line changed from the bottom to the top of the for loop).

#### Maximum Allowed Damage
Now, since the durability is `maxDamage - currentDamage`, `maxAllowedDamage` can be  expressed as `maxDamage - 1` for normal items or `maxDamage - 2` for _special_ items (i.e. swords, tridents or another user-defined item). In order to distinguish normal items from "special" ones (and for simplicity when adding more special items), I added a `isItemSpecial(Item)` method in `BlockMixin.java`.

### Extending to user-defined damage multipliers
Instead of using 1 for normal items and 2 for special ones, we just only have to use `damageMultiplier`, as it contains the damage to deal whether its a sword or not. 

### The "Keep tool from breaking" option
In this case we must only check if the tool has one durability more (i.e. subtract 1 from `maxAllowedDamage`) to prevent breaking the last block.

**Note**: I don't know if sword-like items were excluded before this change, but now they are included as `damageMultiplier` and `maxAllowedDamage` include both damages for special and normal items. In case it has to be only for non-special items, the last bit of the condition must change from `(config.restrictions.keepToolFromBreaking && hand.getDamage() >= maxAllowedDamage - 1)` to `(config.restrictions.keepToolFromBreaking && !isItemSpecial(handItem) && hand.getDamage() >= maxAllowedDamage - 1)`.

### Finally, the bug is now fixed! Yaay! :D

(Obviously I did ran some tests varying parameters and tools)

## Regarding for-loop optimization
Changed the classic for loop in BlockMixin.veinMine() for an enhanced for loop (see https://stackoverflow.com/questions/18410035/ways-to-iterate-over-a-list-in-java).

## Regarding numeric bounds of the configuration parameters
While I was debugging the for loop & the "Keep tool from breaking" option, I noticed that `damageMultiplier` and `swordMultiplier` could have negative values (what could lead to possible bugs), so I added the bounds for all the numeric parameters I found (I don't know if there are more numeric parameters in the config, but I did that to the ones I could find).

Edit2: I also have a question about `SimpleVeinminerClient.changeClientRadius`, where the new radius is set between 1 and the server radius, and then in `SimpleConfigClient.setRadius` this value is again clampled between 1 and 5: Should the server radius also be clamped between 1 and 5 or should the clientRadius be from 1 to the server radius?

Edit5: I would suggest to clamp the server radius to 3, as I was experimenting with the server side of the mod and had to wait around _one whole minute_ to get the veinmined blocks (with `radius = 10` & `maxBlocks = 5`); even sometimes the server crashed (due to the crawlers) or I -the guest- was disconnected automatically because of the 'unresponsive' server. Moreover, due to this lag, no block could get dropped even if I was not veinmining.

## Regarding the fix of the crash when freezing the preview
The crash ocurred only when the user followed these steps: freezing the preview while veinmining was toggled off, toggling on again veinmining, and finally looking at a vinemineabke block. This crash was caused by `blocksToHighlight`, as it couldn't update its value when veinmining was toggled on (because it does not change while the preview is frozen).

---
Edit1: Changed a comma
Edit4: Added description of the crash fix
Edit6: Fixed typo